### PR TITLE
modify alarm clock logic

### DIFF
--- a/devices/timer.c
+++ b/devices/timer.c
@@ -90,8 +90,7 @@ void timer_sleep(int64_t ticks) {
     int64_t start = timer_ticks();
 
     ASSERT(intr_get_level() == INTR_ON);
-    while (timer_elapsed(start) < ticks)
-        thread_yield();
+    thread_sleep(start + ticks);
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -119,6 +118,7 @@ static void
 timer_interrupt(struct intr_frame *args UNUSED) {
     ticks++;
     thread_tick();
+    thread_awake(ticks);
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -90,6 +90,7 @@ struct thread {
     enum thread_status status; /* Thread state. */
     char name[16];             /* Name (for debugging purposes). */
     int priority;              /* Priority. */
+    int64_t wake_tick;         /* 일어날 시간 */
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem; /* List element. */
@@ -139,6 +140,10 @@ int thread_get_nice(void);
 void thread_set_nice(int);
 int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
+
+/* alarm clock function*/
+void thread_sleep(int64_t wake_tick);
+void thread_awake(int64_t ticks);
 
 void do_iret(struct intr_frame *tf);
 


### PR DESCRIPTION
기존 busy waiting 방식에서 sleep/awake 방식으로 변경
- running에서 scheduling시 ready_list로 가지 않고 sleep_list로 감
- timer interrupt가 호출될 때마다 thread_awake함수가 sleep_list에서 깨울 thread 탐색
- thread가 일어날 시간이 되면 thread_unblock을 통해 ready_list로 감