### PR TITLE
fix args-passing error & implement systemcall-exit

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -88,6 +88,7 @@ struct thread {
     /* Owned by thread.c. */
     tid_t tid;                 /* Thread identifier. */
     enum thread_status status; /* Thread state. */
+    int exit_status;           /* exit state. */
     char name[16];             /* Name (for debugging purposes). */
     int priority;              /* Priority. */
     int origin_priority;       /* origin Priority*/
@@ -95,7 +96,7 @@ struct thread {
 
     struct list donations;     /* 기부해준 스레드 리스트 */
     struct lock *wait_on_lock; /* 내가 기다리는 lock */
-        
+
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;   /* List element. */
     struct list_elem d_elem; /* donations element*/

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -49,6 +49,9 @@ tid_t process_create_initd(const char *file_name) {
         return TID_ERROR;
     strlcpy(fn_copy, file_name, PGSIZE);
 
+    char **save_ptr;
+    strtok_r(file_name, " ", save_ptr);
+
     /* Create a new thread to execute FILE_NAME. */
     tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
     if (tid == TID_ERROR)
@@ -650,13 +653,19 @@ void setup_user_stack(struct intr_frame *if_, uint64_t argc, char *argv[]) {
         memcpy(rsp, argv[i], l);
     }
     rsp -= WORD_SIZE - (acc_l % WORD_SIZE); // padding
-    rsp -= WORD_SIZE;                       // NULL pointer boundary
+    acc_l += WORD_SIZE - (acc_l % WORD_SIZE);
+    rsp -= WORD_SIZE;   // NULL pointer boundary
+    acc_l += WORD_SIZE; // NULL pointer boundary
     for (int i = argc - 1; i >= 0; i--) {
         rsp -= WORD_SIZE;
+        acc_l += WORD_SIZE;
         memcpy(rsp, &temp[i], WORD_SIZE);
     }
+    if_->R.rsi = rsp;
     rsp -= WORD_SIZE;
+    acc_l += WORD_SIZE;
     if_->rsp = rsp;
+    // hex_dump(if_->rsp, if_->rsp, acc_l, true);
     if_->R.rdi = argc;
-    if_->R.rsi = temp[0];
+    // printf("%d %p\n", if_->R.rdi, if_->R.rsi);
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -35,39 +35,74 @@ void syscall_init(void) {
     write_msr(MSR_SYSCALL_MASK,
               FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 }
-
+// halt exit check_addr wait exec fork create remove filesize open close read write
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED) {
     uint64_t syscall_num = f->R.rax;
-        // TODO: Your implementation goes here.
+    // TODO: Your implementation goes here.
     struct thread *curr = thread_current();
-    switch (syscall_num)
-    {
+    switch (syscall_num) {
     case SYS_HALT:
-        power_off();    /* Halt the operating system. */
-    case SYS_EXIT:    /* Terminate this process. */
-    case SYS_FORK:     /* Clone current process. */
-    case SYS_EXEC:     /* Switch current process. */
-    case SYS_WAIT:     /* Wait for a child process to die. */
-    case SYS_CREATE:   /* Create a file. */
-    case SYS_REMOVE:   /* Delete a file. */
-    case SYS_OPEN:     /* Open a file. */
-    case SYS_FILESIZE: /* Obtain a file's size. */
-    case SYS_READ:     /* Read from a file. */
-    case SYS_WRITE:    /* Write to a file. */
-    case SYS_SEEK:     /* Change position in a file. */
-    case SYS_TELL:     /* Report current position in a file. */
-    case SYS_CLOSE: /* Close a file. */
+        power_off(); /* Halt the operating system. */
+        break;
+    case SYS_EXIT: /* Terminate this process. */
+        exit(f->R.rdi);
+        break;
+    case SYS_FORK:
+        break; /* Clone current process. */
+    case SYS_EXEC:
+        break; /* Switch current process. */
+    case SYS_WAIT:
+        break; /* Wait for a child process to die. */
+    case SYS_CREATE:
+        break; /* Create a file. */
+    case SYS_REMOVE:
+        break; /* Delete a file. */
+    case SYS_OPEN:
+        break; /* Open a file. */
+    case SYS_FILESIZE:
+        break; /* Obtain a file's size. */
+    case SYS_READ:
+        break; /* Read from a file. */
+    case SYS_WRITE:
+        printf("%s", f->R.rsi);
+        break; /* Write to a file. */
+    case SYS_SEEK:
+        break; /* Change position in a file. */
+    case SYS_TELL:
+        break; /* Report current position in a file. */
+    case SYS_CLOSE:
+        break; /* Close a file. */
         /* code */
         break;
-    
+
     default:
         break;
     }
-    printf("system call!\n");
+    // printf("system call!\n");
+    // thread_exit();
+}
+
+void check_addr(uint64_t *ptr) {
+    if (ptr == NULL || is_kernel_vaddr(ptr) || pml4_get_page(thread_current()->pml4, ptr))
+        exit(-1);
+}
+
+// void halt(void) NO_RETURN;
+void exit(int status) {
+    thread_current()->exit_status = status;
+    printf("%s: exit(%d)\n", thread_current()->name, thread_current()->exit_status);
     thread_exit();
 }
-
-void check_addr(struct intr_frame *f UNUSED){
-
-}
+// pid_t fork(const char *thread_name);
+// int exec(const char *file);
+// int wait(pid_t);
+// bool create(const char *file, unsigned initial_size);
+// bool remove(const char *file);
+// int open(const char *file);
+// int filesize(int fd);
+// int read(int fd, void *buffer, unsigned length);
+// int write(int fd, const void *buffer, unsigned length);
+// void seek(int fd, unsigned position);
+// unsigned tell(int fd);
+// void close(int fd);


### PR DESCRIPTION
#### 1. Fix args-passing error
- user interrupt frame의 rsi 값이 잘못들어간 점 수정

#### 2. Implement systemcall-exit
- check_addr 함수 구현
    - 주소가 널인지 확인
    - kernel base 보다 큰 주소를 참조하는지 확인
    - 매핑되지 않은 주소를 참조하는지 확인
- thread 구조체 수정
    - exit_status 추가
- exit 시스템 콜 함수 구현
    - 인자로 받은 status를 현재 스레드의 exit_status에 저장
    - thread_exit() 호출을 통한 user process 종료 및 kernel thread 스케쥴링