### PR TITLE
Systemcall open&close

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -93,9 +93,11 @@ struct thread {
     int priority;              /* Priority. */
     int origin_priority;       /* origin Priority*/
     int64_t wake_tick;         /* 일어날 시간 */
+    int fd_count;              /* file descriptor count */
 
     struct list donations;     /* 기부해준 스레드 리스트 */
     struct lock *wait_on_lock; /* 내가 기다리는 lock */
+    struct list fd_list;       /* file descriptor list*/
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;   /* List element. */

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -5,6 +5,12 @@
 
 #define WORD_SIZE 8
 
+struct file_descriptor {
+    int fd;
+    struct file *file;
+    struct list_elem elem;
+};
+
 tid_t process_create_initd(const char *file_name);
 tid_t process_fork(const char *name, struct intr_frame *if_);
 int process_exec(void *f_name);

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -457,10 +457,12 @@ init_thread(struct thread *t, const char *name, int priority) {
     t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);
     t->priority = priority;
     t->origin_priority = priority;
+    t->fd_count = 3;
     t->wait_on_lock = NULL;
     t->magic = THREAD_MAGIC;
 
     list_init(&t->donations);
+    list_init(&t->fd_list);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should


### PR DESCRIPTION
## Systemcall open() 구현
#### thread.h
- thread 구조체에 file descriptor 리스트 추가
- thread 구조체에  fd_count 추가
#### thread.c
- init_thread() 함수에서 구조체에 추가된 fd_list와 fd_count 초기화
#### process.h
- 각 프로세스 마다 fd를 관리하기 위한 file_descriptor 구조체 추가
#### syscall.c
- filesys 코드 접근에 mutual exclusion 보장을 위한 file_lock 추가
- syscall_init() 함수에서 추가한 file_lock 초기화
- open() 함수 구현 -> 인자로 받은 file 이름을 통해 filesys_open 호출. 파일 열기에 성공하면 해당 파일과 thread 구조체의 fd_count로 file_descriptor 구조체를 초기화한다. 이후 초기화된 구조체를 fd_list에 넣는다.
- close() 함수 구현 -> 인자로 받은 fd를 통해 fd_list에서 해당 fd인 element를 찾아서 삭제.