### PR TITLE
hotfix: free fd when fail to open file

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -152,8 +152,10 @@ int open(const char *file) {
     lock_acquire(&file_lock);
     openfile = filesys_open(file);
     lock_release(&file_lock);
-    if (!openfile)
+    if (!openfile) {
+        palloc_free_page(fd);
         return -1;
+    }
 
     fd->fd = curr->fd_count;
     fd->file = openfile;


### PR DESCRIPTION
## HOTFIX

#### syscall.c
- open() 함수에서 file open실패시 미리 할당 받은 fd페이지를 free 시키도록 수정