### PR TITLE
Systemcall fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 */build/
 .vscode/
+commit_msg

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -98,11 +98,14 @@ struct thread {
     struct list donations;     /* 기부해준 스레드 리스트 */
     struct lock *wait_on_lock; /* 내가 기다리는 lock */
     struct list fd_list;       /* file descriptor list*/
+    struct list child_list;    /* child process list*/
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;   /* List element. */
     struct list_elem d_elem; /* donations element*/
+    struct list_elem c_elem; /* child_list element*/
 
+    struct semaphore fork_sema; /* semaphore for fork*/
 #ifdef USERPROG
     /* Owned by userprog/process.c. */
     uint64_t *pml4; /* Page map level 4 */
@@ -114,7 +117,8 @@ struct thread {
 
     /* Owned by thread.c. */
     struct intr_frame tf; /* Information for switching */
-    unsigned magic;       /* Detects stack overflow. */
+    struct intr_frame if_;
+    unsigned magic; /* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -116,9 +116,9 @@ struct thread {
 #endif
 
     /* Owned by thread.c. */
-    struct intr_frame tf; /* Information for switching */
-    struct intr_frame if_;
-    unsigned magic; /* Detects stack overflow. */
+    struct intr_frame tf;  /* Information for switching */
+    struct intr_frame if_; /* Information for fork */
+    unsigned magic;        /* Detects stack overflow. */
 };
 
 /* If false (default), use round-robin scheduler.

--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -4,4 +4,6 @@
 void syscall_init(void);
 void exit(int status);
 
+typedef int pid_t;
+
 #endif /* userprog/syscall.h */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -128,11 +128,12 @@ __do_fork(void *aux) {
     struct thread *parent = (struct thread *)aux;
     struct thread *current = thread_current();
     /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-    struct intr_frame *parent_if = &parent->tf;
+    struct intr_frame *parent_if = &parent->if_;
     bool succ = true;
-    struct file_descriptor *t;
     struct list_elem *e;
+    struct file_descriptor *t;
     struct file_descriptor *n_fd;
+
     /* 1. Read the cpu context to local stack. */
     memcpy(&if_, parent_if, sizeof(struct intr_frame));
     if_.R.rax = 0;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -8,6 +8,7 @@
 #include "threads/interrupt.h"
 #include "threads/mmu.h"
 #include "threads/palloc.h"
+#include "threads/synch.h"
 #include "threads/thread.h"
 #include "threads/vaddr.h"
 #include "userprog/gdt.h"
@@ -26,7 +27,7 @@ static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);
 static void __do_fork(void *);
-
+extern struct lock file_lock;
 /* General process initializer for initd and other process. */
 static void
 process_init(void) {
@@ -93,21 +94,25 @@ duplicate_pte(uint64_t *pte, void *va, void *aux) {
     bool writable;
 
     /* 1. TODO: If the parent_page is kernel page, then return immediately. */
-
+    if (is_kern_pte(pte))
+        return false;
     /* 2. Resolve VA from the parent's page map level 4. */
     parent_page = pml4_get_page(parent->pml4, va);
 
     /* 3. TODO: Allocate new PAL_USER page for the child and set result to
      *    TODO: NEWPAGE. */
+    newpage = palloc_get_page(PAL_USER);
 
     /* 4. TODO: Duplicate parent's page to the new page and
      *    TODO: check whether parent's page is writable or not (set WRITABLE
      *    TODO: according to the result). */
-
+    memcpy(newpage, parent_page, 4096);
+    writable = is_writable(pte);
     /* 5. Add new page to child's page table at address VA with WRITABLE
      *    permission. */
     if (!pml4_set_page(current->pml4, va, newpage, writable)) {
         /* 6. TODO: if fail to insert page, do error handling. */
+        return false;
     }
     return true;
 }
@@ -123,12 +128,14 @@ __do_fork(void *aux) {
     struct thread *parent = (struct thread *)aux;
     struct thread *current = thread_current();
     /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
-    struct intr_frame *parent_if;
+    struct intr_frame *parent_if = &parent->tf;
     bool succ = true;
-
+    struct file_descriptor *t;
+    struct list_elem *e;
+    struct file_descriptor *n_fd;
     /* 1. Read the cpu context to local stack. */
     memcpy(&if_, parent_if, sizeof(struct intr_frame));
-
+    if_.R.rax = 0;
     /* 2. Duplicate PT */
     current->pml4 = pml4_create();
     if (current->pml4 == NULL)
@@ -150,13 +157,31 @@ __do_fork(void *aux) {
      * TODO:       from the fork() until this function successfully duplicates
      * TODO:       the resources of parent.*/
 
+    for (e = list_begin(&parent->fd_list); e != list_end(&parent->fd_list); e = list_next(e)) {
+        t = list_entry(e, struct file_descriptor, elem);
+        n_fd = palloc_get_page(0);
+        n_fd->fd = t->fd;
+        lock_acquire(&file_lock);
+        n_fd->file = file_duplicate(t->file);
+        lock_release(&file_lock);
+        if (n_fd->file == NULL) {
+            palloc_free_page(n_fd);
+            goto error;
+        }
+        list_push_back(&current->fd_list, &n_fd->elem);
+    }
+
     process_init();
 
     /* Finally, switch to the newly created process. */
-    if (succ)
+    if (succ) {
+        sema_up(&parent->fork_sema);
         do_iret(&if_);
+    }
+
 error:
-    thread_exit();
+    sema_up(&parent->fork_sema);
+    exit(TID_ERROR);
 }
 
 /* Switch the current execution context to the f_name.

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -75,7 +75,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
         exit(f->R.rdi);
         break;
     case SYS_FORK:
-        f->R.rax = fork(f->R.rdi, f->R.rsi);
+        f->R.rax = fork(f->R.rdi, f);
         break; /* Clone current process. */
     case SYS_EXEC:
         f->R.rax = exec(f->R.rdi);
@@ -319,6 +319,7 @@ int write(int fd, const void *buffer, unsigned length) {
 pid_t fork(const char *thread_name, struct intr_frame *f) {
     pid_t child_pid;
     struct thread *curr = thread_current();
+
     memcpy(curr->if_, f, sizeof(struct intr_frame));
     child_pid = process_fork(thread_name, f);
     semadown(curr->fork_sema);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -2,6 +2,7 @@
 #include "filesys/file.h"
 #include "filesys/filesys.h"
 #include "intrinsic.h"
+#include "lib/string.h"
 #include "threads/flags.h"
 #include "threads/interrupt.h"
 #include "threads/loader.h"
@@ -320,8 +321,8 @@ pid_t fork(const char *thread_name, struct intr_frame *f) {
     pid_t child_pid;
     struct thread *curr = thread_current();
 
-    memcpy(curr->if_, f, sizeof(struct intr_frame));
+    memcpy(&curr->if_, f, sizeof(struct intr_frame));
     child_pid = process_fork(thread_name, f);
-    semadown(curr->fork_sema);
+    sema_down(&curr->fork_sema);
     return child_pid;
 }


### PR DESCRIPTION
## System call fork() 구현

#### thread.h
- thread 구조체에 fork_sema, if_ 멤버 추가

#### thread.c
- init_thread()
fork_sema 초기화

#### process.c
- __do_fork()
부모의 pml4, file descriptor 등 리소스 복사
부모의 fork_sema up 연산을 통해 fork을 완료되었음을 부모에게 알림
자식이므로 if_.R.rax = 0; 을 통해 0 반환

- duplicate_pte()
parent_page가 kernel page면 반환
부모의 page를 child의 newpage에 복사 후 child의 pml4에 저장

#### syscall.c
- fork()
process_fork 함수의 인자로 시스템콜 핸들러에서 전달받은 인터럽트 프레임 복사 후 전달
자식 프로세스의 fork 완료를 기다리도록 fork_sema down 연산 실행