### PR TITLE
implement syscall-wait

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -1,11 +1,12 @@
 #ifndef THREADS_THREAD_H
 #define THREADS_THREAD_H
 
+#include "filesys/file.h"
 #include "threads/interrupt.h"
+#include "threads/synch.h"
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
-#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -107,6 +108,10 @@ struct thread {
     struct list_elem c_elem; /* child_list element*/
 
     struct semaphore fork_sema; /* semaphore for fork*/
+    struct semaphore wait_sema; /* semaphore for wait*/
+    struct semaphore exit_sema; /* semaphore for exit*/
+
+    struct file *exec_file;
 #ifdef USERPROG
     /* Owned by userprog/process.c. */
     uint64_t *pml4; /* Page map level 4 */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -190,6 +190,8 @@ tid_t thread_create(const char *name, int priority, thread_func *function, void 
     /* Initialize thread. */
     init_thread(t, name, priority);
     tid = t->tid = allocate_tid();
+    list_push_back(&curr->child_list, &t->c_elem);
+
     /* Call the kernel_thread if it scheduled.
      * Note) rdi is 1st argument, and rsi is 2nd argument. */
     t->tf.rip = (uintptr_t)kernel_thread;
@@ -465,6 +467,8 @@ init_thread(struct thread *t, const char *name, int priority) {
     list_init(&t->child_list);
 
     sema_init(&t->fork_sema, 0);
+    sema_init(&t->wait_sema, 0);
+    sema_init(&t->exit_sema, 0);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -21,7 +21,7 @@ void halt(void) NO_RETURN;
 void exit(int status) NO_RETURN;
 pid_t fork(const char *thread_name, struct intr_frame *f);
 int exec(const char *file);
-int wait(pid_t);
+int wait(pid_t pid);
 bool create(const char *file, unsigned initial_size);
 bool remove(const char *file);
 int open(const char *file);
@@ -82,6 +82,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
         f->R.rax = exec(f->R.rdi);
         break; /* Switch current process. */
     case SYS_WAIT:
+        f->R.rax = wait(f->R.rdi);
         break; /* Wait for a child process to die. */
     case SYS_CREATE:
         f->R.rax = create(f->R.rdi, f->R.rsi);
@@ -324,5 +325,11 @@ pid_t fork(const char *thread_name, struct intr_frame *f) {
     memcpy(&curr->if_, f, sizeof(struct intr_frame));
     child_pid = process_fork(thread_name, f);
     sema_down(&curr->fork_sema);
+    return child_pid;
+}
+
+int wait(pid_t pid) {
+    pid_t child_pid;
+    child_pid = process_wait(pid);
     return child_pid;
 }


### PR DESCRIPTION
## System call fork() 구현

#### thread.h
- thread 구조체에 wait_sema, exit_sema, exec_file 멤버 추가

#### thread.c
- thread_create()
현재 쓰레드의 자식 리스트에 새로 만드는 쓰레드 삽입 로직 추가

- init_thread()
wait_sema, exit_sema 초기화

#### process.c
- duplicate_pte()
부모 pte가 kernel_page시 즉시 반환하는데, false가 아닌 true 반환으로 수정
새로운 page 할당 실패 시 return false
parent_page를 newpage로 memcpy시 PGSIZE만큼 복사하도록 수정

 - __do_fork()
 부모 쓰레드의 fd_count를 자식 쓰레드의 fd_count로 복사

- process_wait()
child_list에서 인자로 주어진 tid를 찾고 자식의 wait_sema를 sema_down() (자식이 종료할때까지 대기)
sema_down을 통과하면 자식의 exit_status를 저장 후 child_list에서 삭제
자식의 exit_sema를 sema_up() (자식이 종료해도 된다는 신호)하고 저장해 둔 exit_status를 반환

- process_exit()
process_cleanup()을 즉시 실행
종료하려는 쓰레드가 메인 쓰레드가 아니고, exec_file이 존재한다면 exec_file을 close (현재 실행하고 있는 쓰레드를 실행한 file의 쓰기 권한을 allow 해주고 file close)
child_list가 비어있지 않다면, 모든 자식들의 exit_sema를  sema_up() (부모가 자식에게 종료한다는 신호)
현재 쓰레드의 wait_sema를 sema_up() (wait 하고 있는 부모쓰레드에게 종료했다는 신호)
현재 쓰레드의 exit_sema를 sema_down() (부모가 종료해도 된다는 신호를 기다림)

- load()
filesys_open() 함수 실행 전 후로 file_lock 설정
load 하고 있는 file의 쓰기 권한을 deny
load 성공 시 file을 닫지 않고, exec_file 에 file 저장

#### syscall.c
- wait()
process_wait()를 호출