### PR TITLE
Multi oom

### DIFF
--- a/threads/synch.c
+++ b/threads/synch.c
@@ -185,7 +185,7 @@ void lock_acquire(struct lock *lock) {
     if (lock->holder) {
         curr->wait_on_lock = lock;
         list_insert_ordered(&lock->holder->donations, &thread_current()->d_elem, compare_priority, NULL);
-        while (curr && lock_t) {
+        while (curr && lock_t && lock_t->holder) {
             donate_priority(lock_t, curr);
             if (!curr->wait_on_lock)
                 break;

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -184,6 +184,7 @@ tid_t thread_create(const char *name, int priority, thread_func *function, void 
 
     /* Allocate thread. */
     t = palloc_get_page(PAL_ZERO);
+    // t = palloc_get_multiple(PAL_ZERO, 100);
     if (t == NULL)
         return TID_ERROR;
 
@@ -591,6 +592,7 @@ do_schedule(int status) {
         struct thread *victim =
             list_entry(list_pop_front(&destruction_req), struct thread, elem);
         palloc_free_page(victim);
+        // palloc_free_multiple(victim, 100);
     }
     thread_current()->status = status;
     schedule();

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -115,6 +115,7 @@ duplicate_pte(uint64_t *pte, void *va, void *aux) {
      *    permission. */
     if (!pml4_set_page(current->pml4, va, newpage, writable)) {
         /* 6. TODO: if fail to insert page, do error handling. */
+        palloc_free_page(newpage);
         return false;
     }
     return true;
@@ -188,6 +189,7 @@ __do_fork(void *aux) {
     }
 
 error:
+    current->tid = TID_ERROR;
     sema_up(&parent->fork_sema);
     exit(TID_ERROR);
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -6,6 +6,7 @@
 #include "threads/flags.h"
 #include "threads/interrupt.h"
 #include "threads/loader.h"
+#include "threads/malloc.h"
 #include "threads/palloc.h"
 #include "threads/synch.h"
 #include "threads/thread.h"
@@ -148,7 +149,7 @@ int open(const char *file) {
 
     check_addr(file);
 
-    fd = palloc_get_page(PAL_ZERO);
+    fd = calloc(1, sizeof *fd);
     if (fd == NULL)
         return TID_ERROR;
 
@@ -156,7 +157,7 @@ int open(const char *file) {
     openfile = filesys_open(file);
     lock_release(&file_lock);
     if (!openfile) {
-        palloc_free_page(fd);
+        free(fd);
         return -1;
     }
 
@@ -186,7 +187,7 @@ void close(int fd) {
         lock_acquire(&file_lock);
         file_close(t->file);
         lock_release(&file_lock);
-        palloc_free_page(t);
+        free(t);
     }
 }
 


### PR DESCRIPTION
## memory leak check

#### synch.c
- lock_acquire()
lock->holder가 NULL일때 예외처리 추가 (wsl 환경에서 syn-read, write test fail)

#### process.c
- duplicate_pte()
자식 쓰레드의 pml4에 newpage set 실패 시 newpage free

- __do_fork()
file_descriptor 구조체 할당을 기존 palloc에서 calloc으로 수정
file_duplicate 실패 시 calloc된 file_descriptor 구조체 free
fork error 시 자식의 tid를 TID_ERROR로 설정 (부모가 자식의 fork 성공여부를 알기 위해)

- process_exit()
file_close하는 로직을 process_cleanup() 함수 내부로 이동 (exec 할 때도 기존 실행파일을 file_close 하기 위해)
현재 쓰레드의 fd_list에서 file을 close하고 calloc된 file_descriptor 구조체 free

#### syscall.c
- open()
file_descriptor 구조체 할당을 기존 palloc에서 calloc으로 수정
file_open 실패 시 calloc된 file_descriptor 구조체 free

- close()
calloc된 file_descriptor 구조체 free

- fork()
자식의 fork 성공여부를 알기 위해 child_list 순회 로직 추가
child->tid 반환