### PR TITLE
implement syscall dup2 & refactoring project2

### DIFF
--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -7,7 +7,6 @@
 
 struct file_descriptor {
     int fd;
-    bool is_dup;
     bool _stdin;
     bool _stdout;
     bool _stderr;

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -7,8 +7,13 @@
 
 struct file_descriptor {
     int fd;
+    bool is_dup;
+    bool _stdin;
+    bool _stdout;
+    bool _stderr;
     struct file *file;
     struct list_elem elem;
+    struct list dup_list;
 };
 
 tid_t process_create_initd(const char *file_name);

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -26,4 +26,9 @@ void process_activate(struct thread *next);
 void argument_parsing(char *file_name, uint64_t *argc, char *argv[]);
 void setup_user_stack(struct intr_frame *if_, uint64_t argc, char *argv[]);
 
+void duplicate_fd(struct file_descriptor *new_fd, struct file_descriptor *old_fd, int newfd);
+struct file_descriptor *get_fd(int fd, struct file_descriptor **root);
+struct thread *get_child(tid_t child_pid);
+int fd_list_init(void);
+
 #endif /* userprog/process.h */

--- a/userprog/Make.vars
+++ b/userprog/Make.vars
@@ -7,6 +7,6 @@ TEST_SUBDIRS = tests/userprog tests/filesys/base tests/userprog/no-vm tests/thre
 GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.no-extra
 
 # Uncomment the lines below to submit/test extra for project 2.
-# TDEFINE := -DEXTRA2
-# TEST_SUBDIRS += tests/userprog/dup2
-# GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra
+TDEFINE := -DEXTRA2
+TEST_SUBDIRS += tests/userprog/dup2
+GRADING_FILE = $(SRCDIR)/tests/userprog/Grading.extra

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -173,9 +173,6 @@ __do_fork(void *aux) {
         if (n_fd == NULL)
             goto error;
 
-        n_fd->fd = t->fd;
-        list_init(&n_fd->dup_list);
-
         if (t->file) {
             lock_acquire(&file_lock);
             n_fd->file = file_duplicate(t->file);
@@ -186,10 +183,14 @@ __do_fork(void *aux) {
             }
         } else {
             memcpy(n_fd, t, sizeof *n_fd);
-            n_fd->_stdin = t->_stdin;
-            n_fd->_stdout = t->_stdout;
-            n_fd->_stderr = t->_stderr;
         }
+
+        n_fd->fd = t->fd;
+        n_fd->_stdin = t->_stdin;
+        n_fd->_stdout = t->_stdout;
+        n_fd->_stderr = t->_stderr;
+        n_fd->is_dup = t->is_dup;
+        list_init(&n_fd->dup_list);
 
         list_push_back(&current->fd_list, &n_fd->elem);
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -158,6 +158,7 @@ int open(const char *file) {
 
     check_addr(file);
 
+    // multi-oom test 속도를 위한 파일개수 제한
     if (list_size(&curr->fd_list) > 128)
         return -1;
 


### PR DESCRIPTION
## syscall dup2
#### process.h
- file_descriptor 구조체에 _stdin, _stdout, _stderr, dup_list 멤버 추가
#### Make.vars
- dup2 test를 위한 Extra test 주석 해제

#### process.c
- fd_list_init()
fd_list에서 stdin, stdout, stderror 에 해당하는 fd 초기화 하는 함수 추가
- duplicate_fd()
old_fd에서 new_fd로 복사하는 함수 추가
- get_fd()
 fd_list와 fd의 dup_list를 순회하며 인자로 주어진 file_descriptor를 찾는 함수 추가 (+해당 fd의 root 설정)
- get_chid()
 child_list를 순회하며 인자로 주어진 child_pid에 해당하는 child_thread 찾는 함수 추가
- _do_fork()
fd_list를 순회하면서 해당 fd를 복사하는 로직에서 fd가 dup_list가 존재하는 fd라면   dup_list를 순회하며 dup_list의 fd도 복사하는 로직으로 수정
- process_exec()
fd_list_init()을 호출하여 fd_list 초기화 로직 추가
- process_exit()
fd_list를 순회하며 fd를 free시켜주는 로직에서 fd가 dup_list가 존재하는 fd라면 dup_list를 순회하며 dup_list의 fd도 free 시켜주는 로직으로 수정

#### syscall.c

- dup2()
인자로받은 oldfd에 해당하는 filedescriptor의 복사본을 생성하고 해당 복사본의 fd값은 newfd값이 되도록 하는 함수 추가
oldfd와 newfd에 해당하는 filedescriptor를 찾는 getfd()를 호출 후
  1. oldfd에 해당하는 filedescriptor가 없다면 -1 반환
  2. oldfd와 newfd가 같다면 newfd 반환
  3. newfd에 해당하는 filedescriptor가 이미 존재한다면 해당 filedescriptor close
  4. 복사본 생성을 위한 calloc 후 oldfd값에 해당하는 filedescriptor를 new_fd로 복사 
  5. 새로운 filedescriptor인 new_fd의 elem을 fd_list에서 old_fd인 filedescriptor에 연결된 dup_list에 삽입
- open() & close() & seek() & tell() & filesize() & read() & write() & fork()
filedescriptor를 fd_list에서 찾는 로직 getfd()호출로 수정