### PR TITLE
 implement Memory Management

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -47,6 +47,7 @@ struct page {
 
     /* Your implementation */
     struct hash_elem hash_elem;
+    bool writable ;
     /* Per-type data are binded into the union.
      * Each function automatically detects the current union */
     union {

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -5,6 +5,7 @@
 #include "vm/inspect.h"
 #include <hash.h>
 #include <vaddr.h>
+#include <mmu.h>
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
@@ -68,8 +69,10 @@ spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 
     page = malloc(sizeof(struct page));
 
-    page->va = va;
+    page->va = pg_round_down(va);
     e = hash_find(&spt, &page->hash_elem);
+
+    free(page); //?다시 생각해보기
 
     return e != NULL ? hash_entry(e, struct page, hash_elem) : NULL;
 }
@@ -80,7 +83,7 @@ bool spt_insert_page(struct supplemental_page_table *spt UNUSED,
     struct hash_elem *e;
 
     e = hash_insert(&spt, &page->hash_elem);
-    return e != NULL ? hash_entry(e, struct page, hash_elem) : NULL;
+    return e != NULL ? true : false;
 }
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
@@ -114,6 +117,9 @@ vm_evict_frame(void) {
 static struct frame *
 vm_get_frame(void) {
     struct frame *frame = NULL;
+    
+    frame=calloc(1,sizeof(struct frame));
+    frame->kva=palloc_get_page(PAL_USER|PAL_ZERO);
 
     ASSERT(frame != NULL);
     ASSERT(frame->page == NULL);
@@ -151,8 +157,10 @@ void vm_dealloc_page(struct page *page) {
 /* Claim the page that allocate on VA. */
 bool vm_claim_page(void *va UNUSED) {
     struct page *page = NULL;
-    /* TODO: Fill this function */
+    struct thread *current=thread_current();
 
+    /* TODO: Fill this function */
+    page=spt_find_page(&current->spt,va);
     return vm_do_claim_page(page);
 }
 
@@ -160,12 +168,15 @@ bool vm_claim_page(void *va UNUSED) {
 static bool
 vm_do_claim_page(struct page *page) {
     struct frame *frame = vm_get_frame();
+    struct thread * current= thread_current();
+    uint64_t pml4 =current->pml4;
 
     /* Set links */
     frame->page = page;
     page->frame = frame;
 
     /* TODO: Insert page table entry to map page's VA to frame's PA. */
+    pml4_set_page(pml4, page->va, frame->kva, page->writable);
 
     return swap_in(page, frame->kva);
 }


### PR DESCRIPTION
## Memory Management
### vm.h
---
 - page 구조체에 hash_elem, writable 추가 
### vm.c
---
#### implement supplemental page table

 - supplemental_page_table_init()
    - spt의 page 메모리 hash 구조체 size로 할당 후 hash_init
- spt_find_page()
   - page malloc 후 page의 va를 페이지 경계로 내림하여 페이지 크기로 정렬된 주소로 설정
   - hash_find를 이용해 해당 page반환
- spt_insert_page()
   - hash_insert()를 이용해 spt에 page 삽입

#### implement Frame Management
- vm_get_frame()
   - frame calloc, kva palloc
- vm_do_claim_page()
   - pml4_set_page()를 통해 page의 va를 frame의 kva를 매핑
- vm_claim_page()
   - spt_find_page()를 통해 spt에서 va에 해당하는 page반환 
