### PR TITLE
implement Anonymous page

### DIFF
--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -15,6 +15,13 @@ struct file_descriptor {
     struct list dup_list;
 };
 
+struct load_aux {
+    struct file *file;
+    off_t offset;
+    size_t page_read_bytes;
+    size_t page_zero_bytes;
+};
+
 tid_t process_create_initd(const char *file_name);
 tid_t process_fork(const char *name, struct intr_frame *if_);
 int process_exec(void *f_name);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -65,6 +65,7 @@ struct page {
 struct frame {
     void *kva;
     struct page *page;
+    struct list_elem frame_elem;
 };
 
 /* The function table for page operations.
@@ -88,7 +89,7 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
-    struct hash *pages;
+    struct hash hash_spt;
 };
 
 #include "threads/thread.h"

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -160,7 +160,7 @@ void hash_apply(struct hash *h, hash_action_func *action) {
     }
 }
 
-/* Initializes I for iterating hash table H.
+/* Initializes I for iterating hash table 
 
    Iteration idiom:
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -722,6 +722,7 @@ lazy_load_segment(struct page *page, void *aux) {
     file_seek(file,offset);
     /* Load this page. */
     if (file_read(file, page->frame->kva, page_read_bytes) != (int)page_read_bytes)
+
         return false;
 
     memset(page->frame->kva + page_read_bytes, 0, page_zero_bytes);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -710,6 +710,23 @@ lazy_load_segment(struct page *page, void *aux) {
     /* TODO: Load the segment from the file */
     /* TODO: This called when the first page fault occurs on address VA. */
     /* TODO: VA is available when calling this function. */
+    if (page == NULL)
+        return false;
+
+    struct load_aux *seg_aux = (struct load_aux *)aux;
+    struct file *file = seg_aux->file;
+    off_t offset = seg_aux->offset;
+    size_t page_read_bytes = seg_aux->page_read_bytes;
+    size_t page_zero_bytes = seg_aux->page_zero_bytes;
+
+    file_seek(file,offset);
+    /* Load this page. */
+    if (file_read(file, page->frame->kva, page_read_bytes) != (int)page_read_bytes)
+        return false;
+
+    memset(page->frame->kva + page_read_bytes, 0, page_zero_bytes);
+
+    return true;
 }
 
 /* Loads a segment starting at offset OFS in FILE at address
@@ -732,7 +749,6 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
     ASSERT(pg_ofs(upage) == 0);
     ASSERT(ofs % PGSIZE == 0);
-
     while (read_bytes > 0 || zero_bytes > 0) {
         /* Do calculate how to fill this page.
          * We will read PAGE_READ_BYTES bytes from FILE
@@ -741,7 +757,12 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
         size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
         /* TODO: Set up aux to pass information to the lazy_load_segment. */
-        void *aux = NULL;
+        struct load_aux *aux = calloc(1, sizeof(struct load_aux));
+        aux->file = file;
+        aux->offset = ofs;
+        aux->page_read_bytes = page_read_bytes;
+        aux->page_zero_bytes = page_zero_bytes;
+
         if (!vm_alloc_page_with_initializer(VM_ANON, upage,
                                             writable, lazy_load_segment, aux))
             return false;
@@ -750,6 +771,7 @@ load_segment(struct file *file, off_t ofs, uint8_t *upage,
         read_bytes -= page_read_bytes;
         zero_bytes -= page_zero_bytes;
         upage += PGSIZE;
+        ofs += page_read_bytes;
     }
     return true;
 }
@@ -765,6 +787,12 @@ setup_stack(struct intr_frame *if_) {
      * TODO: You should mark the page is stack. */
     /* TODO: Your code goes here */
 
+    if (vm_alloc_page(VM_ANON | VM_MARKER_0, stack_bottom, 1)) {
+        if (vm_claim_page(stack_bottom)) {
+            if_->rsp = USER_STACK;
+            success=true;
+        }
+    }
     return success;
 }
 #endif /* VM */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -719,7 +719,7 @@ lazy_load_segment(struct page *page, void *aux) {
     size_t page_read_bytes = seg_aux->page_read_bytes;
     size_t page_zero_bytes = seg_aux->page_zero_bytes;
 
-    file_seek(file,offset);
+    file_seek(file, offset);
     /* Load this page. */
     if (file_read(file, page->frame->kva, page_read_bytes) != (int)page_read_bytes)
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -121,7 +121,7 @@ void syscall_handler(struct intr_frame *f UNUSED) {
 }
 
 void check_addr(uint64_t *ptr) {
-    if (ptr == NULL || is_kernel_vaddr(ptr) || !pml4_get_page(thread_current()->pml4, ptr))
+    if (ptr == NULL || is_kernel_vaddr(ptr) || !spt_find_page(&thread_current()->spt, ptr))
         exit(-1);
 }
 


### PR DESCRIPTION
## Anonymous page
### process.h
---
-  lazy_load_segment 함수의 aux 구조체인 load_aux  struct 추가

### process.c
---
 - lazy_load_segment()
   - aux로 받은 load_aux  (file, page_read_byte, offset,page_zero_bytes)을 이용하여 segment_load 로직 구현
   - file_seek으로 파일의 오프셋 세팅
   - ELF파일 을 읽고 리턴
 
 - load_segment()
   - lazy_load_segment() 인자인 aux를 load_aux  로 정의
   - vm_alloc_page_initializer()함수를 통해 lazy_load_segment를 init 함수, load_aux 를 aux로 UNINIT 페이지를 spt에 등록
 
- setup_stack()
   - vm_alloc_page함수를 통해 VM_MARKER_0를 마킹한 ANON타입 페이지 할당
   - 해당 페이지를 claim
   - rsp를 USER_STACK으로 설정

### syscall.c
---
- check_addr()
   - pml4에 페이지가 install 되어 있는지 확인하는 대신 spt에 페이지가 할당 되었는지 확인하는 로직으로 수정

### vm.c
---
- vm_alloc_page_with_initializer()
   - calloc 으로 page 할당
   - 타입에 맞는 initializer 함수를 인자로 uninit_new()실행
   - page의 writable을 writable로 세팅
   - spt에 페이지 삽입

 - vm_try_handle_fault ()
   - 보조 테이블에 페이지가 없으면 진짜 fault 처리
   - 페이지를 찾은 뒤 해당 페이지에 프레임 할당 (vm_do_claim_page 함수 호출)

- supplemental_page_table_copy()
   - src spt를 순회하며 dst의 spt로 page 복사
   - src 페이지가 uninit 타입이라면 vm_alloc_page_with_initializer 함수 호출 하여 src 페이지와 동일한 uninit페이지를 spt에 할당
   - src 페이지가 uninit 타입이아니라면 vm_alloc_page로 페이지를 하나 할당 받은 뒤 즉시 claim 이후 claim한 페이지에 src_page의 프레임에 있는 컨텐츠를 복사

- supplemental_page_table_kill ()
   - hash_clear 함수로 spt의 모든 page를 destroy한다.
