### PR TITLE
feat: implement stack growth

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -119,6 +119,8 @@ struct thread {
 #ifdef VM
     /* Table for whole virtual memory owned by thread. */
     struct supplemental_page_table spt;
+    void *rsp ;
+    
 #endif
 
     /* Owned by thread.c. */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -67,8 +67,12 @@ void syscall_init(void) {
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED) {
     uint64_t syscall_num = f->R.rax;
-    // TODO: Your implementation goes here.
     struct thread *curr = thread_current();
+
+#ifdef VM
+    curr->rsp = f->rsp; // 추가
+#endif
+
     switch (syscall_num) {
     case SYS_HALT:
         power_off(); /* Halt the operating system. */


### PR DESCRIPTION
## stack growth
### thread.h
---

- struct thread{}
   -  VM일 경우 thread struct에 rsp 필드추가 

### syscall.c
---
 - syscall_handler()
   - VM일 경우 현재 thread의 rsp에 인터럽트 프레임 rsp 할당
### vm.c
---
- vm_try_handle_fault()
   -  addr가 NULL이거나 커널 주소라면 false 리턴
   - 접근하려는 페이지가 물리 메모리에 존재하지 않는 경우
       - user가 참이면(현재 쓰레드가 user모드에서 page fault를 일으켰을 경우)  인터럽트 프레임의 rsp를
        그렇지 않으면(현재 쓰레드가 kernel모드에서 page fault를 일으켰을 경우) 현재 스레드의 rsp를 사용
       - 접근한 주소 addr가 사용자 스택 영역 내에 있으며, 스택 확장이 필요한 경우 vm_stack_growth를 호출하여 스택을 확장
       - 페이지 테이블에서 찾은 페이지가 없는 경우 false를 반환
       - 쓰기 접근인데 페이지가 쓰기 가능하지 않은 경우 false를 반환
       - vm_do_claim_page() 호출하여 매핑처리

- vm_stack_growth()
  - vm_alloc_page () 호출하여 새로운 페이지를 할당, VM_ANON | VM_MARKER_0은 이 페이지가 익명 페이지임을 나타냄
  - vm_claim_page() 호출하여 가상주소로 페이지를 찾고 물리 프레임과 매핑 
