### PR TITLE
Memory mapped files

### DIFF
--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -22,6 +22,8 @@ struct load_aux {
     size_t page_zero_bytes;
 };
 
+bool lazy_load_segment(struct page *page, void *aux);
+
 tid_t process_create_initd(const char *file_name);
 tid_t process_fork(const char *name, struct intr_frame *if_);
 int process_exec(void *f_name);

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -20,6 +20,7 @@ struct load_aux {
     off_t offset;
     size_t page_read_bytes;
     size_t page_zero_bytes;
+    size_t length;
 };
 
 bool lazy_load_segment(struct page *page, void *aux);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -705,8 +705,7 @@ install_page(void *upage, void *kpage, bool writable) {
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 
-static bool
-lazy_load_segment(struct page *page, void *aux) {
+bool lazy_load_segment(struct page *page, void *aux) {
     /* TODO: Load the segment from the file */
     /* TODO: This called when the first page fault occurs on address VA. */
     /* TODO: VA is available when calling this function. */

--- a/vm/file.c
+++ b/vm/file.c
@@ -3,6 +3,7 @@
 #include "vm/vm.h"
 #include "threads/vaddr.h"
 #include "userprog/process.h"
+#include "threads/mmu.h"
 
 static bool file_backed_swap_in(struct page *page, void *kva);
 static bool file_backed_swap_out(struct page *page);
@@ -29,21 +30,32 @@ bool file_backed_initializer(struct page *page, enum vm_type type, void *kva) {
 }
 
 /* Swap in the page by read contents from the file. */
-static bool
-file_backed_swap_in(struct page *page, void *kva) {
+static bool file_backed_swap_in(struct page *page, void *kva) {
     struct file_page *file_page UNUSED = &page->file;
 }
 
 /* Swap out the page by writeback contents to the file. */
-static bool
-file_backed_swap_out(struct page *page) {
+static bool file_backed_swap_out(struct page *page) {
     struct file_page *file_page UNUSED = &page->file;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
-static void
-file_backed_destroy(struct page *page) {
-    struct file_page *file_page UNUSED = &page->file;
+static void file_backed_destroy(struct page *page) {
+    struct load_aux *aux = page->uninit.aux;
+    struct thread *curr = thread_current();
+
+    if (pml4_is_dirty(curr->pml4, page->va)) {
+        file_write_at(aux->file, page->va, aux->page_read_bytes, aux->offset);
+        pml4_set_dirty(curr->pml4, page->va, 0);
+    }
+
+    if (page->frame) {
+        list_remove(&page->frame->frame_elem);
+        page->frame->page = NULL;
+        free(page->frame);
+        page->frame = NULL;
+    }
+    pml4_clear_page(curr->pml4, page->va);
 }
 
 /* Do the mmap */
@@ -51,8 +63,8 @@ void *
 do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset) {
     void *upage = addr;
     struct file *file_for_map = file_reopen(file);
-    uint32_t zero_bytes = PGSIZE - (length % PGSIZE);
-    uint32_t read_bytes = length;
+    size_t read_bytes = file_length(file_for_map) < length ? file_length(file_for_map) : length;
+    size_t zero_bytes = PGSIZE - read_bytes % PGSIZE;
 
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
     ASSERT(pg_ofs(upage) == 0);
@@ -70,6 +82,7 @@ do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset
         aux->offset = offset;
         aux->page_read_bytes = page_read_bytes;
         aux->page_zero_bytes = page_zero_bytes;
+        aux->length = length;
 
         if (!vm_alloc_page_with_initializer(VM_FILE, upage,
                                             writable, lazy_load_segment, aux))
@@ -86,4 +99,17 @@ do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset
 
 /* Do the munmap */
 void do_munmap(void *addr) {
+    struct thread *curr = thread_current();
+    struct page *page = spt_find_page(&curr->spt, addr);
+    struct load_aux *aux = page->uninit.aux;
+    int map_pg_cnt = ((aux->length) % PGSIZE == 0) ? (aux->length / PGSIZE) : (aux->length / PGSIZE + 1);
+
+    while (map_pg_cnt != 0) {
+        if (page) {
+            destroy(page);
+        }
+        addr += PGSIZE;
+        page = spt_find_page(&curr->spt, addr);
+        map_pg_cnt--;
+    }
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,6 +1,8 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
+#include "threads/vaddr.h"
+#include "userprog/process.h"
 
 static bool file_backed_swap_in(struct page *page, void *kva);
 static bool file_backed_swap_out(struct page *page);
@@ -46,8 +48,40 @@ file_backed_destroy(struct page *page) {
 
 /* Do the mmap */
 void *
-do_mmap(void *addr, size_t length, int writable,
-        struct file *file, off_t offset) {
+do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset) {
+    void *upage = addr;
+    struct file *file_for_map = file_reopen(file);
+    uint32_t zero_bytes = PGSIZE - (length % PGSIZE);
+    uint32_t read_bytes = length;
+
+    ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+    ASSERT(pg_ofs(upage) == 0);
+    ASSERT(offset % PGSIZE == 0);
+    while (read_bytes > 0 || zero_bytes > 0) {
+        /* Do calculate how to fill this page.
+         * We will read PAGE_READ_BYTES bytes from FILE
+         * and zero the final PAGE_ZERO_BYTES bytes. */
+        size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+        size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+        /* TODO: Set up aux to pass information to the lazy_load_segment. */
+        struct load_aux *aux = calloc(1, sizeof(struct load_aux));
+        aux->file = file_for_map;
+        aux->offset = offset;
+        aux->page_read_bytes = page_read_bytes;
+        aux->page_zero_bytes = page_zero_bytes;
+
+        if (!vm_alloc_page_with_initializer(VM_FILE, upage,
+                                            writable, lazy_load_segment, aux))
+            return false;
+
+        /* Advance. */
+        read_bytes -= page_read_bytes;
+        zero_bytes -= page_zero_bytes;
+        upage += PGSIZE;
+        offset += page_read_bytes;
+    }
+    return addr;
 }
 
 /* Do the munmap */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -21,6 +21,7 @@ void vm_init(void) {
     register_inspect_intr();
     /* DO NOT MODIFY UPPER LINES. */
     /* TODO: Your code goes here. */
+     list_init(&frame_table);
 }
 
 /* Get the type of the page. This function is useful if you want to know the
@@ -57,7 +58,8 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
          * TODO: and then create "uninit" page struct by calling uninit_new. You
          * TODO: should modify the field after calling the uninit_new. */
         page = calloc(1, sizeof(struct page));
-
+        if (!page)
+            return false;
         if (VM_TYPE(type) == VM_ANON)
             uninit_new(page, upage, init, type, aux, anon_initializer);
         else if (VM_TYPE(type) == VM_FILE)
@@ -127,9 +129,10 @@ static struct frame *vm_get_frame(void) {
 
     frame = calloc(1, sizeof(struct frame));
     frame->kva = palloc_get_page(PAL_USER | PAL_ZERO);
-    if (!frame->kva) {
+    if (!frame->kva) 
         PANIC("todo");
-    }
+    
+    list_push_back(&frame_table,&frame->frame_elem);
 
     ASSERT(frame != NULL);
     ASSERT(frame->page == NULL);
@@ -138,7 +141,7 @@ static struct frame *vm_get_frame(void) {
 
 /* Growing the stack. */
 static void vm_stack_growth(void *addr UNUSED) {
-    vm_alloc_page(VM_ANON | VM_MARKER_0, addr, 1);
+    vm_alloc_page(VM_ANON | VM_MARKER_0, pg_round_down(addr), 1);
     vm_claim_page(addr);
 }
 


### PR DESCRIPTION
## Memory mapped files
### process.h
---

- struct load_aux{}
   -  do_munmap()에서 page count 를 위한 length변수 추가 

### syscall.c
---
 - syscall_handler()
   - SYS_MMAP, SYS_MUNMAP 분기 추가
- read()
   -   length 길이 까지 PGSIZE 만큼 더해 반복하면서 check_buffer() 수행 로직 추가
- check_buffer()
   -   buffer에 맞는 spt내의 페이지가 쓰기형식이 아니면 exit(-1) 처리 함수 추가
- mmap()
-  매핑이 이루어질 수 없는 경우들에 대해 예외처리 추가
   - offset이 page-aligned되지 않은 경우
   -  addr가 없는 경우, addr가 page-aligned 되지 않은 경우, addr가 user 영역이 아닌 경우, addr + length가 user 영역이 아닌 경우
   - addr에 할당된 페이지가 이미 존재하는 경우
   - 파일이 없거나, 파일 길이가 0 이하일 경우
   - length 길이가 0이하 일 경우
- munmap()
   - do_munmap() 호출

### file.c
---
-  do_mmap()
   - 해당 파일에 대한 read_bytes나 zero_bytes가 있는 동안 lazy load정책을 사용하여 VM_FILE 타입으로 vm_alloc_page_with_initializer() 실행
   -  매핑된 가상 주소의 시작 주소를 반환
- do_munmap()
   - mmap된 페이지 수가 0이 아닐 때까지 반복하며 spt에서 addr에 해당하는 페이지가 존재하는 지를 확인해 존재하면 destroy()함수 실행
- file_backed_destroy()
   - pml4에 해당 페이지가 만약 변경 사항이 존재한다면, 해당 데이터를 DISK의 파일에 변경사항 반영
   - 변경사항 적용 후 해당 페이지에 대해 dirty-bit를 0으로 수정 (변경사항이 없음) 
   - 페이지에 연결된 프레임이 존재하는지 확인하여, 존재한다면,해당 프레임을 제거하고, 페이지 테이블의 매핑 정보를 제거
   - pml4_clear_page() 페이지 테이블에서 현재 페이지의 매핑 정보를 제거

### vm.c
--- 

- vm_alloc_page_with_initializer()
   - 페이지 없으면 false 반환 예외처리 추가
- vm_stack_growth ()
   - addr를 page-aligned 처리후 인자 전달로 수정