### PR TITLE
Swap in/out

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -45,7 +45,7 @@ struct page {
     const struct page_operations *operations;
     void *va;            /* Address in terms of user space */
     struct frame *frame; /* Back reference for frame */
-
+    uint32_t slot_no;
     /* Your implementation */
     struct hash_elem hash_elem;
     bool writable ;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -45,7 +45,7 @@ struct page {
     const struct page_operations *operations;
     void *va;            /* Address in terms of user space */
     struct frame *frame; /* Back reference for frame */
-    uint32_t slot_no;
+    size_t slot_no;
     /* Your implementation */
     struct hash_elem hash_elem;
     bool writable ;

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -24,16 +24,17 @@ static const struct page_operations anon_ops = {
 };
 
 /* Initialize the data for anonymous pages */
-void vm_anon_init(void) {
+void vm_anon_init(void)
+{
     /* TODO: Set up the swap_disk. */
     swap_disk = disk_get(1, 1);
     size_t swap_size = disk_size(swap_disk) / (PGSIZE / DISK_SECTOR_SIZE);
     swap_table = bitmap_create(swap_size);
-    bitmap_set_all(swap_table, true);
 }
 
 /* Initialize the file mapping */
-bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
+bool anon_initializer(struct page *page, enum vm_type type, void *kva)
+{
     /* Set up the handler */
     page->operations = &anon_ops;
 
@@ -42,36 +43,54 @@ bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
 
 /* Swap in the page by read contents from the swap disk. */
 static bool
-anon_swap_in(struct page *page, void *kva) {
+anon_swap_in(struct page *page, void *kva)
+{
     struct anon_page *anon_page = &page->anon;
     int slot_no = page->slot_no;
 
-    for (int i = 0; i < 8; i++)
-        disk_read(swap_disk, slot_no * 8 + i, kva + (i * DISK_SECTOR_SIZE));
+    if (bitmap_test(swap_table, slot_no) == false)
+    {
+        return false;
+    }
+
+    for (int i = 0; i < 8; ++i)
+    {
+        disk_read(swap_disk, (slot_no * 8) + i, kva + (DISK_SECTOR_SIZE * i));
+    }
+
     bitmap_set(swap_table, slot_no, false);
+
+    return true;
 }
 
 /* Swap out the page by writing contents to the swap disk. */
 static bool
-anon_swap_out(struct page *page) {
+anon_swap_out(struct page *page)
+{
     struct anon_page *anon_page = &page->anon;
     int slot_no = bitmap_scan(swap_table, 0, 1, false);
+
     if (slot_no == BITMAP_ERROR)
+    {
         return false;
+    }
 
-    page->slot_no = slot_no;
-
-    for (int i = 0; i < 8; i++)
-        disk_write(swap_disk, slot_no * 8 + i, page->frame->kva + DISK_SECTOR_SIZE * i);
+    for (int i = 0; i < 8; ++i)
+    {
+        disk_write(swap_disk, (slot_no * 8) + i, page->va + (DISK_SECTOR_SIZE * i));
+    }
 
     bitmap_set(swap_table, slot_no, true);
     pml4_clear_page(thread_current()->pml4, page->va);
+
+    page->slot_no = slot_no;
 
     return true;
 }
 
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void
-anon_destroy(struct page *page) {
+anon_destroy(struct page *page)
+{
     struct anon_page *anon_page = &page->anon;
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -18,11 +18,13 @@ static const struct page_operations file_ops = {
 };
 
 /* The initializer of file vm */
-void vm_file_init(void) {
+void vm_file_init(void)
+{
 }
 
 /* Initialize the file backed page */
-bool file_backed_initializer(struct page *page, enum vm_type type, void *kva) {
+bool file_backed_initializer(struct page *page, enum vm_type type, void *kva)
+{
     /* Set up the handler */
     page->operations = &file_ops;
 
@@ -30,47 +32,63 @@ bool file_backed_initializer(struct page *page, enum vm_type type, void *kva) {
 }
 
 /* Swap in the page by read contents from the file. */
-static bool file_backed_swap_in(struct page *page, void *kva) {
+static bool file_backed_swap_in(struct page *page, void *kva)
+{
     struct file_page *file_page UNUSED = &page->file;
-    struct load_aux *aux = page->uninit.aux;
-
     if (page == NULL)
         return false;
+    struct load_aux *aux = page->uninit.aux;
 
-    file_seek(aux->file, aux->offset);
-    file_read(aux->file, page->frame->kva, aux->page_read_bytes);
+    struct file *file = aux->file;
+    off_t offset = aux->offset;
+    size_t page_read_bytes = aux->page_read_bytes;
+    size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-    memset (kva + aux->page_read_bytes, 0, aux->page_zero_bytes);
+    file_seek(file, offset);
+
+    if (file_read(file, kva, page_read_bytes) != (int)page_read_bytes)
+    {
+        return false;
+    }
+
+    memset(kva + page_read_bytes, 0, page_zero_bytes);
+
     return true;
 }
 
 /* Swap out the page by writeback contents to the file. */
-static bool file_backed_swap_out(struct page *page) {
+static bool file_backed_swap_out(struct page *page)
+{
     struct file_page *file_page UNUSED = &page->file;
     struct load_aux *aux = page->uninit.aux;
 
     if (page == NULL)
         return false;
 
-    if (pml4_is_dirty(thread_current()->pml4, page->va)) {
-        file_write_at(aux->file, page->frame->kva, aux->page_read_bytes, aux->offset);
+    // 사용 되었던 페이지(dirty page)인지 체크
+    if (pml4_is_dirty(thread_current()->pml4, page->va))
+    {
+        file_write_at(aux->file, page->va, aux->page_read_bytes, aux->offset);
         pml4_set_dirty(thread_current()->pml4, page->va, 0);
     }
+
     pml4_clear_page(thread_current()->pml4, page->va);
-    return true;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
-static void file_backed_destroy(struct page *page) {
+static void file_backed_destroy(struct page *page)
+{
     struct load_aux *aux = page->uninit.aux;
     struct thread *curr = thread_current();
 
-    if (pml4_is_dirty(curr->pml4, page->va)) {
+    if (pml4_is_dirty(curr->pml4, page->va))
+    {
         file_write_at(aux->file, page->va, aux->page_read_bytes, aux->offset);
         pml4_set_dirty(curr->pml4, page->va, 0);
     }
 
-    if (page->frame) {
+    if (page->frame)
+    {
         list_remove(&page->frame->frame_elem);
         page->frame->page = NULL;
         free(page->frame);
@@ -81,7 +99,8 @@ static void file_backed_destroy(struct page *page) {
 
 /* Do the mmap */
 void *
-do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset) {
+do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset)
+{
     void *upage = addr;
     struct file *file_for_map = file_reopen(file);
     size_t read_bytes = file_length(file_for_map) < length ? file_length(file_for_map) : length;
@@ -90,7 +109,8 @@ do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
     ASSERT(pg_ofs(upage) == 0);
     ASSERT(offset % PGSIZE == 0);
-    while (read_bytes > 0 || zero_bytes > 0) {
+    while (read_bytes > 0 || zero_bytes > 0)
+    {
         /* Do calculate how to fill this page.
          * We will read PAGE_READ_BYTES bytes from FILE
          * and zero the final PAGE_ZERO_BYTES bytes. */
@@ -119,14 +139,17 @@ do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset
 }
 
 /* Do the munmap */
-void do_munmap(void *addr) {
+void do_munmap(void *addr)
+{
     struct thread *curr = thread_current();
     struct page *page = spt_find_page(&curr->spt, addr);
     struct load_aux *aux = page->uninit.aux;
     int map_pg_cnt = ((aux->length) % PGSIZE == 0) ? (aux->length / PGSIZE) : (aux->length / PGSIZE + 1);
 
-    while (map_pg_cnt != 0) {
-        if (page) {
+    while (map_pg_cnt != 0)
+    {
+        if (page)
+        {
             destroy(page);
         }
         addr += PGSIZE;

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -9,10 +9,12 @@
 #include "string.h"
 
 struct list frame_table;
+struct list_elem *start;
 void destructor(struct hash_elem *e, void *aux);
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
-void vm_init(void) {
+void vm_init(void)
+{
     vm_anon_init();
     vm_file_init();
 #ifdef EFILESYS /* For project 4 */
@@ -22,15 +24,18 @@ void vm_init(void) {
     /* DO NOT MODIFY UPPER LINES. */
     /* TODO: Your code goes here. */
     list_init(&frame_table);
+    start = list_begin(&frame_table);
 }
 
 /* Get the type of the page. This function is useful if you want to know the
  * type of the page after it will be initialized.
  * This function is fully implemented now. */
 enum vm_type
-page_get_type(struct page *page) {
+page_get_type(struct page *page)
+{
     int ty = VM_TYPE(page->operations->type);
-    switch (ty) {
+    switch (ty)
+    {
     case VM_UNINIT:
         return VM_TYPE(page->uninit.type);
     default:
@@ -46,14 +51,16 @@ static struct frame *vm_evict_frame(void);
 /* Create the pending page object with initializer. If you want to create a
  * page, do not create it directly and make it through this function or
  * `vm_alloc_page`. */
-bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable, vm_initializer *init, void *aux) {
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable, vm_initializer *init, void *aux)
+{
 
     ASSERT(VM_TYPE(type) != VM_UNINIT)
 
     struct supplemental_page_table *spt = &thread_current()->spt;
     struct page *page;
     /* Check wheter the upage is already occupied or not. */
-    if (spt_find_page(spt, upage) == NULL) {
+    if (spt_find_page(spt, upage) == NULL)
+    {
         /* TODO: Create the page, fetch the initialier according to the VM type,
          * TODO: and then create "uninit" page struct by calling uninit_new. You
          * TODO: should modify the field after calling the uninit_new. */
@@ -76,7 +83,8 @@ err:
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
-struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED)
+{
     struct page *page = NULL;
     struct hash_elem *e;
 
@@ -91,67 +99,77 @@ struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va 
 }
 
 /* Insert PAGE into spt with validation. */
-bool spt_insert_page(struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) {
+bool spt_insert_page(struct supplemental_page_table *spt UNUSED, struct page *page UNUSED)
+{
     struct hash_elem *e;
 
     e = hash_insert(&spt->hash_spt, &page->hash_elem);
     return e != NULL ? false : true;
 }
 
-void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page)
+{
     vm_dealloc_page(page);
     return true;
 }
 
 /* Get the struct frame, that will be evicted. */
-static struct frame *vm_get_victim(void) {
+static struct frame *vm_get_victim(void)
+{
     struct frame *victim = NULL;
-    struct list_elem *e;
-    struct frame *cur;
-    /* TODO: The policy for eviction is up to you. */
-    for (e = list_begin(&frame_table); e != list_end(&frame_table);) {
-        victim = list_entry(e, struct frame, frame_elem);
-        if (pml4_is_accessed(thread_current()->pml4, victim->page->va))
-            pml4_set_accessed(thread_current()->pml4, victim->page->va, 0);
-        else {
-            list_remove(e);
+    struct thread *curr = thread_current();
+    struct list_elem *e = start;
 
-            return victim;
-        }
-        if (e->next == list_end(&frame_table))
-            e = list_begin(&frame_table);
+    for (start = e; start != list_end(&frame_table); start = list_next(start))
+    {
+        victim = list_entry(start, struct frame, frame_elem);
+        if (pml4_is_accessed(curr->pml4, victim->page->va))
+            pml4_set_accessed(curr->pml4, victim->page->va, 0);
         else
-            e = list_next(e);
+            return victim;
     }
 
-    return NULL;
+    for (start = list_begin(&frame_table); start != e; start = list_next(start))
+    {
+        victim = list_entry(start, struct frame, frame_elem);
+        if (pml4_is_accessed(curr->pml4, victim->page->va))
+            pml4_set_accessed(curr->pml4, victim->page->va, 0);
+        else
+            return victim;
+    }
+
+    return victim;
 }
 
 /* Evict one page and return the corresponding frame.
  * Return NULL on error.*/
-static struct frame *vm_evict_frame(void) {
-    struct frame *victim UNUSED = vm_get_victim();
+static struct frame *vm_evict_frame(void)
+{
+    struct frame *victim = vm_get_victim();
     /* TODO: swap out the victim and return the evicted frame. */
-    if (!victim)
-        return NULL;
-    if (swap_out(victim->page)) {
-        palloc_free_page(victim->kva);
-        free(victim);
-    }
-    return NULL;
+    if (victim->page)
+        swap_out(victim->page);
+
+    return victim;
 }
 
 /* palloc() and get frame. If there is no available page, evict the page
  * and return it. This always return valid address. That is, if the user pool
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
-static struct frame *vm_get_frame(void) {
+static struct frame *vm_get_frame(void)
+{
     struct frame *frame = NULL;
 
     frame = calloc(1, sizeof(struct frame));
     frame->kva = palloc_get_page(PAL_USER | PAL_ZERO);
-    if (!frame->kva)
-        vm_evict_frame();
+    frame->page = NULL;
+    if (frame->kva == NULL)
+    {
+        frame = vm_evict_frame();
+        frame->page = NULL;
+        return frame;
+    }
 
     list_push_back(&frame_table, &frame->frame_elem);
 
@@ -161,17 +179,20 @@ static struct frame *vm_get_frame(void) {
 }
 
 /* Growing the stack. */
-static void vm_stack_growth(void *addr UNUSED) {
+static void vm_stack_growth(void *addr UNUSED)
+{
     vm_alloc_page(VM_ANON | VM_MARKER_0, pg_round_down(addr), 1);
     vm_claim_page(addr);
 }
 
 /* Handle the fault on write_protected page */
-static bool vm_handle_wp(struct page *page UNUSED) {
+static bool vm_handle_wp(struct page *page UNUSED)
+{
 }
 
 /* Return true on success */
-bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool user UNUSED, bool write UNUSED, bool not_present UNUSED)
+{
     struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
     struct page *page = spt_find_page(spt, addr);
     void *rsp = f->rsp;
@@ -179,9 +200,11 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool us
     if (addr == NULL || is_kernel_vaddr(addr))
         return false;
 
-    if (not_present) {
+    if (not_present)
+    {
         rsp = user ? f->rsp : thread_current()->rsp;
-        if (USER_STACK > addr && addr >= USER_STACK - (1 << 20) && addr >= rsp - 8) {
+        if (USER_STACK > addr && addr >= USER_STACK - (1 << 20) && addr >= rsp - 8)
+        {
             vm_stack_growth(pg_round_down(addr));
             return true;
         }
@@ -196,13 +219,15 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool us
 
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
-void vm_dealloc_page(struct page *page) {
+void vm_dealloc_page(struct page *page)
+{
     destroy(page);
     free(page);
 }
 
 /* Claim the page that allocate on VA. */
-bool vm_claim_page(void *va UNUSED) {
+bool vm_claim_page(void *va UNUSED)
+{
     struct page *page = NULL;
     struct thread *current = thread_current();
 
@@ -214,7 +239,8 @@ bool vm_claim_page(void *va UNUSED) {
 }
 
 /* Claim the PAGE and set up the mmu. */
-static bool vm_do_claim_page(struct page *page) {
+static bool vm_do_claim_page(struct page *page)
+{
     struct frame *frame = vm_get_frame();
     struct thread *current = thread_current();
     uint64_t pml4 = current->pml4;
@@ -231,18 +257,21 @@ static bool vm_do_claim_page(struct page *page) {
 }
 
 /* Initialize new supplemental page table */
-void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
+void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED)
+{
 
     hash_init(&spt->hash_spt, page_hash, page_less, NULL);
 }
 
 /* Copy supplemental page table from src to dst */
-bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, struct supplemental_page_table *src UNUSED) {
+bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, struct supplemental_page_table *src UNUSED)
+{
 
     struct hash_iterator i;
 
     hash_first(&i, &src->hash_spt);
-    while (hash_next(&i)) {
+    while (hash_next(&i))
+    {
         struct page *parent_page = hash_entry(hash_cur(&i), struct page, hash_elem);
         struct page *child_page;
 
@@ -252,10 +281,13 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
         void *aux = parent_page->uninit.aux;
         bool writable = parent_page->writable;
 
-        if (parent_page->operations->type == VM_UNINIT) {
+        if (parent_page->operations->type == VM_UNINIT)
+        {
             if (!vm_alloc_page_with_initializer(page_type, upage, writable, init, aux))
                 return false;
-        } else {
+        }
+        else
+        {
             if (!vm_alloc_page(page_type, upage, writable))
                 return false;
             if (!vm_claim_page(parent_page->va))
@@ -268,25 +300,29 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
 }
 
 /* Free the resource hold by the supplemental page table */
-void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
+void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED)
+{
     /* TODO: Destroy all the supplemental_page_table hold by thread and
      * TODO: writeback all the modified contents to the storage. */
 
     hash_clear(&spt->hash_spt, destructor);
 }
 
-void destructor(struct hash_elem *e, void *aux) {
+void destructor(struct hash_elem *e, void *aux)
+{
     struct page *page = hash_entry(e, struct page, hash_elem);
     vm_dealloc_page(page);
 }
 /* Returns a hash value for page p. */
-unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED) {
+unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED)
+{
     const struct page *p = hash_entry(p_, struct page, hash_elem);
     return hash_bytes(&p->va, sizeof p->va);
 }
 
 /* Returns true if page a precedes page b. */
-bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED) {
+bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED)
+{
     const struct page *a = hash_entry(a_, struct page, hash_elem);
     const struct page *b = hash_entry(b_, struct page, hash_elem);
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -13,8 +13,7 @@ struct lock frame_table_lock;
 void destructor(struct hash_elem *e, void *aux);
 /* Initializes the virtual memory subsystem by invoking each subsystem's
  * intialize codes. */
-void vm_init(void)
-{
+void vm_init(void) {
     vm_anon_init();
     vm_file_init();
 #ifdef EFILESYS /* For project 4 */
@@ -31,11 +30,9 @@ void vm_init(void)
  * type of the page after it will be initialized.
  * This function is fully implemented now. */
 enum vm_type
-page_get_type(struct page *page)
-{
+page_get_type(struct page *page) {
     int ty = VM_TYPE(page->operations->type);
-    switch (ty)
-    {
+    switch (ty) {
     case VM_UNINIT:
         return VM_TYPE(page->uninit.type);
     default:
@@ -51,20 +48,16 @@ static struct frame *vm_evict_frame(void);
 /* Create the pending page object with initializer. If you want to create a
  * page, do not create it directly and make it through this function or
  * `vm_alloc_page`. */
-bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable, vm_initializer *init, void *aux)
-{
+bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable, vm_initializer *init, void *aux) {
 
     ASSERT(VM_TYPE(type) != VM_UNINIT)
 
     struct supplemental_page_table *spt = &thread_current()->spt;
     struct page *page;
-    /* Check wheter the upage is already occupied or not. */
-    if (spt_find_page(spt, upage) == NULL)
-    {
-        /* TODO: Create the page, fetch the initialier according to the VM type,
-         * TODO: and then create "uninit" page struct by calling uninit_new. You
-         * TODO: should modify the field after calling the uninit_new. */
+
+    if (spt_find_page(spt, upage) == NULL) {
         page = calloc(1, sizeof(struct page));
+        
         if (!page)
             return false;
         if (VM_TYPE(type) == VM_ANON)
@@ -72,8 +65,6 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writabl
         else if (VM_TYPE(type) == VM_FILE)
             uninit_new(page, upage, init, type, aux, file_backed_initializer);
 
-        /* TODO: Insert the page into the spt. */
-        // hash_insert(&spt->hash_spt, &page->hash_elem);
         page->writable = writable;
 
         return spt_insert_page(spt, page);
@@ -83,8 +74,7 @@ err:
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
-struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED)
-{
+struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
     struct page *page = NULL;
     struct hash_elem *e;
 
@@ -99,31 +89,27 @@ struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va 
 }
 
 /* Insert PAGE into spt with validation. */
-bool spt_insert_page(struct supplemental_page_table *spt UNUSED, struct page *page UNUSED)
-{
+bool spt_insert_page(struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) {
     struct hash_elem *e;
 
     e = hash_insert(&spt->hash_spt, &page->hash_elem);
     return e != NULL ? false : true;
 }
 
-void spt_remove_page(struct supplemental_page_table *spt, struct page *page)
-{
+void spt_remove_page(struct supplemental_page_table *spt, struct page *page) {
     vm_dealloc_page(page);
     return true;
 }
 
 /* Get the struct frame, that will be evicted. */
-static struct frame *vm_get_victim(void)
-{
+static struct frame *vm_get_victim(void) {
     struct frame *victim = NULL;
     struct thread *curr = thread_current();
 
     lock_acquire(&frame_table_lock);
-    struct list_elem *start = list_begin(&frame_table);
-    for (start; start != list_end(&frame_table); start = list_next(start))
-    {
-        victim = list_entry(start, struct frame, frame_elem);
+
+    for (struct list_elem *e = list_begin(&frame_table); e != list_end(&frame_table); e = list_next(e)) {
+        victim = list_entry(e, struct frame, frame_elem);
         if (victim->page == NULL) // frame에 할당된 페이지가 없는 경우 (page가 destroy된 경우 )
         {
             lock_release(&frame_table_lock);
@@ -131,8 +117,7 @@ static struct frame *vm_get_victim(void)
         }
         if (pml4_is_accessed(curr->pml4, victim->page->va))
             pml4_set_accessed(curr->pml4, victim->page->va, 0);
-        else
-        {
+        else {
             lock_release(&frame_table_lock);
             return victim;
         }
@@ -143,8 +128,7 @@ static struct frame *vm_get_victim(void)
 
 /* Evict one page and return the corresponding frame.
  * Return NULL on error.*/
-static struct frame *vm_evict_frame(void)
-{
+static struct frame *vm_evict_frame(void) {
     struct frame *victim = vm_get_victim();
     /* TODO: swap out the victim and return the evicted frame. */
     if (victim->page)
@@ -157,15 +141,13 @@ static struct frame *vm_evict_frame(void)
  * and return it. This always return valid address. That is, if the user pool
  * memory is full, this function evicts the frame to get the available memory
  * space.*/
-static struct frame *vm_get_frame(void)
-{
+static struct frame *vm_get_frame(void) {
     struct frame *frame = NULL;
 
     frame = calloc(1, sizeof(struct frame));
     frame->kva = palloc_get_page(PAL_USER | PAL_ZERO);
     frame->page = NULL;
-    if (frame->kva == NULL)
-    {
+    if (frame->kva == NULL) {
         frame = vm_evict_frame();
         frame->page = NULL;
         return frame;
@@ -181,20 +163,17 @@ static struct frame *vm_get_frame(void)
 }
 
 /* Growing the stack. */
-static void vm_stack_growth(void *addr UNUSED)
-{
+static void vm_stack_growth(void *addr UNUSED) {
     vm_alloc_page(VM_ANON | VM_MARKER_0, pg_round_down(addr), 1);
     vm_claim_page(addr);
 }
 
 /* Handle the fault on write_protected page */
-static bool vm_handle_wp(struct page *page UNUSED)
-{
+static bool vm_handle_wp(struct page *page UNUSED) {
 }
 
 /* Return true on success */
-bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool user UNUSED, bool write UNUSED, bool not_present UNUSED)
-{
+bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
     struct supplemental_page_table *spt UNUSED = &thread_current()->spt;
     struct page *page = spt_find_page(spt, addr);
     void *rsp = f->rsp;
@@ -202,11 +181,9 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool us
     if (addr == NULL || is_kernel_vaddr(addr))
         return false;
 
-    if (not_present)
-    {
+    if (not_present) {
         rsp = user ? f->rsp : thread_current()->rsp;
-        if (USER_STACK > addr && addr >= USER_STACK - (1 << 20) && addr >= rsp - 8)
-        {
+        if (USER_STACK > addr && addr >= USER_STACK - (1 << 20) && addr >= rsp - 8) {
             vm_stack_growth(pg_round_down(addr));
             return true;
         }
@@ -221,15 +198,13 @@ bool vm_try_handle_fault(struct intr_frame *f UNUSED, void *addr UNUSED, bool us
 
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
-void vm_dealloc_page(struct page *page)
-{
+void vm_dealloc_page(struct page *page) {
     destroy(page);
     free(page);
 }
 
 /* Claim the page that allocate on VA. */
-bool vm_claim_page(void *va UNUSED)
-{
+bool vm_claim_page(void *va UNUSED) {
     struct page *page = NULL;
     struct thread *current = thread_current();
 
@@ -241,8 +216,7 @@ bool vm_claim_page(void *va UNUSED)
 }
 
 /* Claim the PAGE and set up the mmu. */
-static bool vm_do_claim_page(struct page *page)
-{
+static bool vm_do_claim_page(struct page *page) {
     struct frame *frame = vm_get_frame();
     struct thread *current = thread_current();
     uint64_t pml4 = current->pml4;
@@ -259,21 +233,18 @@ static bool vm_do_claim_page(struct page *page)
 }
 
 /* Initialize new supplemental page table */
-void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED)
-{
+void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
 
     hash_init(&spt->hash_spt, page_hash, page_less, NULL);
 }
 
 /* Copy supplemental page table from src to dst */
-bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, struct supplemental_page_table *src UNUSED)
-{
+bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, struct supplemental_page_table *src UNUSED) {
 
     struct hash_iterator i;
 
     hash_first(&i, &src->hash_spt);
-    while (hash_next(&i))
-    {
+    while (hash_next(&i)) {
         struct page *parent_page = hash_entry(hash_cur(&i), struct page, hash_elem);
         struct page *child_page;
 
@@ -283,13 +254,10 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
         void *aux = parent_page->uninit.aux;
         bool writable = parent_page->writable;
 
-        if (parent_page->operations->type == VM_UNINIT)
-        {
+        if (parent_page->operations->type == VM_UNINIT) {
             if (!vm_alloc_page_with_initializer(page_type, upage, writable, init, aux))
                 return false;
-        }
-        else
-        {
+        } else {
             if (!vm_alloc_page(page_type, upage, writable))
                 return false;
             if (!vm_claim_page(parent_page->va))
@@ -302,29 +270,22 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED, st
 }
 
 /* Free the resource hold by the supplemental page table */
-void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED)
-{
-    /* TODO: Destroy all the supplemental_page_table hold by thread and
-     * TODO: writeback all the modified contents to the storage. */
-
+void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
     hash_clear(&spt->hash_spt, destructor);
 }
 
-void destructor(struct hash_elem *e, void *aux)
-{
+void destructor(struct hash_elem *e, void *aux) {
     struct page *page = hash_entry(e, struct page, hash_elem);
     vm_dealloc_page(page);
 }
 /* Returns a hash value for page p. */
-unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED)
-{
+unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED) {
     const struct page *p = hash_entry(p_, struct page, hash_elem);
     return hash_bytes(&p->va, sizeof p->va);
 }
 
 /* Returns true if page a precedes page b. */
-bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED)
-{
+bool page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED) {
     const struct page *a = hash_entry(a_, struct page, hash_elem);
     const struct page *b = hash_entry(b_, struct page, hash_elem);
 


### PR DESCRIPTION
## Swap in/out
### vm.h
---

- struct Page{}
   -  anon_swap_in(), anon_swap_out()에서 page 슬롯번호를 위한 slot_no변수 추가 

### anon.c

---

- vm_anon_init()
   -  disk_get()를 사용하여 스왑 디스크 설정
   - 스왑 디스크의 크기를 페이지 크기를 섹터의 크기로 나눈 값으로 나눠 스왑 테이블 생성
   - bitmap_create()를 사용하여 비트맵 생성

- anon_swap_in()
   - bitmap_test()을 사용하여 해당 페이지의 슬롯이 사용 가능한지 확인
   - disk_read()를 for문으로 반복하여 디스크로부터 페이지의 내용을 읽어와 메모리로 복사 
   - 페이지를 Swap in 했으므로 bitmap_set()를 사용하여 해당 슬롯을 다시 사용 가능하다고 표시

- anon_swap_out()
   - bitmap_scan_and_flip()를 사용하여 사용 가능한 슬롯의 번호를 스왑 테이블에서 찾음
   - 사용 가능한 슬롯을 찾지 못한 경우 함수를 종료
   - 페이지를 여러 섹터로 나누어 disk_write()를 for문으로 반복하여 디스크에 기록
   - pml4_clear_page()로 페이지 테이블에서 해당 페이지를 제거
   - 페이지의 슬롯 번호를 업데이트

### file.c
---
-  file_backed_swap_in()
   - 페이지가 NULL인 경우 함수를 종료하고 false를 반환
   - 페이지의 초기화(load_aux) 데이터를 가져옴 (파일 객체, 오프셋, 페이지 읽기 바이트 수, 페이지 제로 바이트 수)
   - file_read_at()를 사용하여 파일에서 페이지의 내용을 읽어옴, 만약 읽은 바이트 수가 예상한 바이트 수와 다르면 false반환
   - memset()을 사용하여 읽은 페이지의 나머지 부분을 0으로 초기화

- file_backed_swap_out()
   - 페이지의 초기화(load_aux) 데이터를 가져옴 (파일 객체, 오프셋, 페이지 읽기 바이트 수, 페이지 제로 바이트 수)
   - 페이지가 NULL인 경우 함수를 종료하고 false를 반환
   - pml4_is_dirty()를 사용하여 만약 페이지가 변경되었다면, file_write_at()를 사용하여 변경된 페이지의 내용을 파일에 씀, 그리고 페이지의 변경 상태를 0으로 
   - 페이지의 프레임을 NULL로 설정
   - pml4_clear_page()를 사용하여 페이지 테이블에서 페이지를 제거

### vm.c
--- 

- vm_init()
   - frame_table 리스트와 frame_table_lock 락 초기화
- vm_get_victim()
   - 프레임 테이블을 순회하면서 희생자 프레임을 선택하는 함수
   - 만약 victim->page == NULL이면 프레임에 할당된 페이지가 없는 경우라서 즉, 페이지가 파괴된 경우에는 해당 프레임을 희생자로 선택하고 반환
   - pml4_is_accessed()를 사용하여 최근 사용된 페이지라면 페이지의 "액세스" 비트를 0으로 설정, 다른 프레임을 희생자로 선택

- vm_evict_frame()
  - vm_get_victim()를 호출하여 페이지 교체 알고리즘에서 후보로 선정된 프레임을 가져옴
  - 프레임에 할당된 페이지가 있는 경우에만 페이지를 스왑아웃
  - 스왑아웃된 후보 프레임을 반환

- vm_get_frame()
  - 만약, frame->kva == NULL 라면, 페이지 할당에 실패한 경우라서 페이지 교체 알고리즘을 사용하여 페이지를 교체
  - 이때, vm_evict_frame 함수를 호출하여 후보 프레임을 가져와서 반환
  - list_push_back() 사용하여 할당된 프레임을 프레임 테이블의 뒤쪽에 추가
