### PR TITLE
Copy on write

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -49,7 +49,7 @@ struct page {
     /* Your implementation */
     struct hash_elem hash_elem;
     bool writable ;
-    bool copy_on_write;
+    bool parent_writable;
     /* Per-type data are binded into the union.
      * Each function automatically detects the current union */
     union {

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -49,6 +49,7 @@ struct page {
     /* Your implementation */
     struct hash_elem hash_elem;
     bool writable ;
+    bool copy_on_write;
     /* Per-type data are binded into the union.
      * Each function automatically detects the current union */
     union {
@@ -66,6 +67,7 @@ struct frame {
     void *kva;
     struct page *page;
     struct list_elem frame_elem;
+    int ref_cnt;
 };
 
 /* The function table for page operations.
@@ -116,5 +118,6 @@ enum vm_type page_get_type(struct page *page);
 
 unsigned page_hash(const struct hash_elem *p_, void *aux UNUSED);
 bool page_less(const struct hash_elem *a_,const struct hash_elem *b_, void *aux UNUSED) ;
+void free_frame(struct frame *frame);
 
 #endif /* VM_VM_H */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -390,7 +390,7 @@ int dup2(int oldfd, int newfd) {
 
 void check_buffer(uint64_t *buffer) {
     struct page *p = spt_find_page(&thread_current()->spt, buffer);
-    if (!p->writable)
+    if (!p->writable&&!p->parent_writable)
         exit(-1);
 }
 

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -81,4 +81,11 @@ static bool anon_swap_out(struct page *page) {
 /* Destroy the anonymous page. PAGE will be freed by the caller. */
 static void anon_destroy(struct page *page) {
     struct anon_page *anon_page = &page->anon;
+    lock_acquire(&swap_table_lock);
+    bitmap_set(swap_table, page->slot_no, true);
+    lock_release(&swap_table_lock);
+    if (page->frame && page->frame->page == page) {
+        free_frame(page->frame);
+    }
+    pml4_clear_page(thread_current()->pml4, page->va);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -5,6 +5,9 @@
 #include "userprog/process.h"
 #include "threads/mmu.h"
 
+struct lock file_swap_lock;
+extern struct lock frame_table_lock;
+
 static bool file_backed_swap_in(struct page *page, void *kva);
 static bool file_backed_swap_out(struct page *page);
 static void file_backed_destroy(struct page *page);
@@ -41,7 +44,7 @@ static bool file_backed_swap_in(struct page *page, void *kva) {
     size_t page_read_bytes = aux->page_read_bytes;
     size_t page_zero_bytes = aux->page_zero_bytes;
 
-    if (file_read_at(file, page->frame->kva, page_read_bytes,offset) != (int)page_read_bytes) {
+    if (file_read_at(file, page->frame->kva, page_read_bytes, offset) != (int)page_read_bytes) {
         return false;
     }
 
@@ -58,12 +61,18 @@ static bool file_backed_swap_out(struct page *page) {
     if (page == NULL)
         return false;
 
+    lock_acquire(&file_swap_lock);
     if (pml4_is_dirty(thread_current()->pml4, page->va)) {
         file_write_at(aux->file, page->frame->kva, aux->page_read_bytes, aux->offset);
+        lock_release(&file_swap_lock);
         pml4_set_dirty(thread_current()->pml4, page->va, 0);
     }
-    page->frame = NULL;
+
     pml4_clear_page(thread_current()->pml4, page->va);
+    page->frame->page = NULL;
+    page->frame = NULL;
+    lock_release(&file_swap_lock);
+
     return true;
 }
 
@@ -71,17 +80,20 @@ static bool file_backed_swap_out(struct page *page) {
 static void file_backed_destroy(struct page *page) {
     struct load_aux *aux = page->uninit.aux;
     struct thread *curr = thread_current();
-
-    if (pml4_is_dirty(curr->pml4, page->va)) {
-        file_write_at(aux->file, page->va, aux->page_read_bytes, aux->offset);
-        pml4_set_dirty(curr->pml4, page->va, 0);
+    lock_acquire(&file_swap_lock);
+    if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+        if (file_write_at(aux->file, page->frame->kva, aux->page_read_bytes, aux->offset) != (int)aux->page_read_bytes) {
+            lock_release(&file_swap_lock);
+            return false;
+        }
+        pml4_set_dirty(thread_current()->pml4, page->va, 0);
     }
+    lock_release(&file_swap_lock);
 
-    if (page->frame) {
-        list_remove(&page->frame->frame_elem);
-        page->frame->page = NULL;
-        free(page->frame);
-        page->frame = NULL;
+    if (page->frame && page->frame->page == page) {
+        lock_acquire(&file_swap_lock);
+        free_frame(page->frame);
+        lock_release(&file_swap_lock);
     }
     pml4_clear_page(curr->pml4, page->va);
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -5,7 +5,7 @@
 #include "userprog/process.h"
 #include "threads/mmu.h"
 
-struct lock file_swap_lock;
+extern struct lock file_lock;
 extern struct lock frame_table_lock;
 
 static bool file_backed_swap_in(struct page *page, void *kva);
@@ -61,17 +61,17 @@ static bool file_backed_swap_out(struct page *page) {
     if (page == NULL)
         return false;
 
-    lock_acquire(&file_swap_lock);
+    lock_acquire(&file_lock);
     if (pml4_is_dirty(thread_current()->pml4, page->va)) {
         file_write_at(aux->file, page->frame->kva, aux->page_read_bytes, aux->offset);
-        lock_release(&file_swap_lock);
+        lock_release(&file_lock);
         pml4_set_dirty(thread_current()->pml4, page->va, 0);
     }
 
     pml4_clear_page(thread_current()->pml4, page->va);
     page->frame->page = NULL;
     page->frame = NULL;
-    lock_release(&file_swap_lock);
+    lock_release(&file_lock);
 
     return true;
 }
@@ -80,20 +80,20 @@ static bool file_backed_swap_out(struct page *page) {
 static void file_backed_destroy(struct page *page) {
     struct load_aux *aux = page->uninit.aux;
     struct thread *curr = thread_current();
-    lock_acquire(&file_swap_lock);
+    lock_acquire(&file_lock);
     if (pml4_is_dirty(thread_current()->pml4, page->va)) {
         if (file_write_at(aux->file, page->frame->kva, aux->page_read_bytes, aux->offset) != (int)aux->page_read_bytes) {
-            lock_release(&file_swap_lock);
+            lock_release(&file_lock);
             return false;
         }
         pml4_set_dirty(thread_current()->pml4, page->va, 0);
     }
-    lock_release(&file_swap_lock);
+    lock_release(&file_lock);
 
     if (page->frame && page->frame->page == page) {
-        lock_acquire(&file_swap_lock);
+        lock_acquire(&file_lock);
         free_frame(page->frame);
-        lock_release(&file_swap_lock);
+        lock_release(&file_lock);
     }
     pml4_clear_page(curr->pml4, page->va);
 }


### PR DESCRIPTION
## Swap in/out
### vm.h
---

- struct Page{}
   -  복사하기 전 부모의 writable을 저장하기 위한 parent_writable변수 추가 
- struct frame{}
   -   COW 구현시 페이지 참조 횟수 저장하기 위한 ref_cnt변수 추가 

### syscall.c

---

- check_buffer()
   - 본인의 writable과 parent_writable를 확인하여 쓰기 가능한 페이지인지 확인, 만약 쓰기가 불가능하다면 exit(-1) 호출

### anon.c

---

- anon_destroy()
   - bitmap_set()를 사용하여 스왑 테이블에서 주어진 페이지의 슬롯을 사용 가능한(true)으로 설정
   - 페이지에 연결된 프레임이 있고(page->frame) 그 프레임의 페이지가 현재 페이지와 동일한 경우에만 free_frame 함수를 호출하여 해당 프레임을 해제
   - pml4_clear_page()를 호출하여 현재 스레드의 페이지 테이블에서 주어진 가상 주소(page->va)에 해당하는 페이지를 제거

### file.c
---
-  file_backed_swap_out()
   - 해당 페이지의 프레임과 페이지를 NULL로 설정

- file_backed_destroy()
   - file_write_at()를 사용하여 일에 주어진 위치(offset)에 주어진 크기(aux->page_read_bytes)만큼 페이지의 내용을 씀, 페이지의 내용은 주어진 프레임의 가상 주소(page->frame->kva)에 저장,  만약 쓰기 작업이 완료되지 않았을 경우 false를 반환
   - 이후, 페이지의 프레임이 존재하고(page->frame) 해당 프레임의 페이지가 현재 페이지와 동일한 경우에만(page->frame->page == page) free_frame()를 호출하여 해당 프레임을 해제

### vm.c
--- 

- vm_evict_frame()
  - swap_out()를 호출하여 선택된 페이지를 스왑 아웃, 성공하면 해당 프레임의 page를 NULL로
  - 스왑 아웃된 페이지의 메모리 공간을 0으로 초기화
  - 스왑 아웃된 페이지의 참조 카운트를 1로 설정
  -  대체된 페이지 프레임을 반환

- vm_get_frame()
  - 페이지 프레임의 참조 횟수를 1로 설정 추가

- vm_handle_wp()
  - 만약, 페이지 프레임의 참조 횟수가 1이면, 이 페이지를 참조하는 다른 프로세스나 스레드가 없으므로, 페이지를 복사하거나 대체할 필요가 없으므로 false를 반환
  - 페이지 프레임의 참조 횟수가 1보다 크면,
     - 새로운 페이지 프레임을 얻음
     - 새로운 페이지 프레임을 할당받지 못한 경우에는 false를 반환
     - memcpy()를 사용하여 이전 페이지의 내용을 새로운 페이지 프레임으로 복사
     - 이전 페이지 프레임의 참조 횟수를 감소
     -  페이지의 프레임을 새로 할당받은 프레임으로 설정
     -  새로운 페이지 프레임의 참조 횟수를 1로 설정
     -  pml4_clear_page()를 사용하여 페이지의 가상 주소에 대한 페이지 테이블 엔트리를 제거
  - 페이지의 쓰기 가능 여부를 true로 설정
  -  pml4_set_page() 사용하여 페이지 테이블에 페이지를 매핑
 -  vm_try_handle_fault()
   - not_present 가 false인 경우, vm_handle_wp 함수를 호출하여 페이지의 쓰기 보호 예외를 처리

- supplemental_page_table_copy()
  - 페이지의 타입이 초기화되지 않은 경우(VM_UNINIT), vm_alloc_page_with_initializer()를 VM_ANON로 새로운 페이지를 할당하고 초기화
  - 페이지의 타입이 파일인 경우(VM_FILE),  새로운 파일 페이지를 할당하고 초기화 후 보조 페이지 테이블에서 새로 할당한 페이지를 찾음(child_page), 페이지의 정보를 복사하고, 참조 횟수를 증가, pml4_set_page()를 사용하여 페이지를 페이지 테이블에 매핑

- free_frame()
  - 만약 페이지 프레임의 참조 횟수가 1보다 크면, 페이지 프레임의 참조 횟수를 감소시키코 Return
  -  페이지 프레임의 참조 횟수가 1인 경우에는 
     - list_remove()를 사용하여  페이지 프레임을 프레임 테이블에서 제거
     - palloc_free_page()를 사용하여 페이지 프레임이 사용하던 메모리를 페이지 할당자를 통해 해제
     -  free()를 사용해 페이지 프레임의 메모리를 해제